### PR TITLE
handle coverage for not covered regions and 1 bp deletions

### DIFF
--- a/bin/perlscript/ClinicalPositions.pl
+++ b/bin/perlscript/ClinicalPositions.pl
@@ -508,6 +508,11 @@ sub checkDeletions {
 											}
 										}
 									}    # End - foreach my $base (@alternatives) {
+									if ((!$cosmic{ $line[1] }{$start}{$end}{$ref}{$var}{'found'}))
+									{
+											$cosmic{ $line[1] }{$start}{$end}{$ref}{$var}{'found'}  = "no";
+											$cosmic{ $line[1] }{$start}{$end}{$ref}{$var}{'tot_rd'} = $totRD;
+									}
 								}    # End - if ( $ref eq $line[5] ) {
 							}
 
@@ -794,15 +799,21 @@ sub printCosmicPos {
 						if ( $link->{'found'} ) {
 							print OUTPUT "\t" . $link->{'found'};
 						}
-						else { print OUTPUT "\t-"; }
+						else { print OUTPUT "\tnot analyzable"; }
 						foreach my $minRD (@minRDs) {
-							if ( $link->{'tot_rd'} ) {
+							if ( defined($link->{'tot_rd'})) {
 								print OUTPUT "\t" . checkReadDepth( $link->{'tot_rd'}, $minRD );
+							}
+							elsif(!defined($link->{'found'})) {
+								print OUTPUT "\tnot covered by design";
 							}
 							else { print OUTPUT "\t-"; }
 						}
-						if ( $link->{'tot_rd'} ) {
+						if (defined($link->{'tot_rd'})) {
 							print OUTPUT "\t" . $link->{'tot_rd'};
+						}
+						elsif(!defined($link->{'found'})) {
+							print OUTPUT "\tnot covered by design";
 						}
 						else { print OUTPUT "\t-"; }
 						print OUTPUT "\t" . $chr . "\t" . $start . "\t" . $end . "\t" . $ref . "\t" . $var;


### PR DESCRIPTION
If a region isn't covered by a design the 'found' will be set to 'not analyzable' and depth columns will be set to 'not covered by design'. Deletions with size 1 that haven't been found will now show the coverage at that position.